### PR TITLE
add whisper_set_xfilesfactor

### DIFF
--- a/whisper/src/bin/whisper-set-aggregation-method.rs
+++ b/whisper/src/bin/whisper-set-aggregation-method.rs
@@ -12,18 +12,18 @@ use whisper::set_aggregation_method;
 #[derive(Debug, StructOpt)]
 #[structopt(name = "whisper-set-aggregation-method")]
 struct Args {
-    /// XFILESFACTOR
-    #[structopt(long = "xFilesFactor", default_value = "0.5")]
-    x_files_factor: f32,
-
-    /// Function to use when aggregating values
-    /// (average, sum, last, max, min, avg_zero, absmax, absmin)
-    #[structopt(long = "aggregationMethod", default_value = "average")]
-    aggregation_method: AggregationMethod,
-
     /// Path to data file
     #[structopt(name = "path", parse(from_os_str))]
     path: PathBuf,
+
+    /// Function to use when aggregating values
+    /// (average, sum, last, max, min, avg_zero, absmax, absmin)
+    #[structopt(name = "aggregationMethod", default_value = "average")]
+    aggregation_method: AggregationMethod,
+
+    /// XFILESFACTOR
+    #[structopt(name = "xFilesFactor", default_value = "0.5")]
+    x_files_factor: f32,
 }
 
 fn main() -> Result<(), Error> {

--- a/whisper/src/bin/whisper-set-xfilesfactor.rs
+++ b/whisper/src/bin/whisper-set-xfilesfactor.rs
@@ -1,0 +1,39 @@
+#[macro_use]
+extern crate structopt;
+extern crate failure;
+extern crate whisper;
+
+use failure::Error;
+use std::path::PathBuf;
+use structopt::StructOpt;
+use whisper::set_x_files_factor;
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "whisper-set-xfilesfactor",
+    about = "Set xFilesFactor for existing whisper files"
+)]
+struct Args {
+    /// Path to data file
+    #[structopt(name = "path", parse(from_os_str), help = "path to whisper file")]
+    path: PathBuf,
+
+    /// XFILESFACTOR
+    #[structopt(name = "xFilesFactor", help = "new xFilesFactor, a float between 0 and 1")]
+    x_files_factor: f32,
+}
+
+fn main() -> Result<(), Error> {
+    let args = Args::from_args();
+
+    let old_x_files_factor = set_x_files_factor(&args.path, args.x_files_factor)?;
+
+    println!(
+        "Updated xFilesFactor: {} ({} -> {})",
+        &args.path.to_str().unwrap(),
+        old_x_files_factor,
+        &args.x_files_factor
+    );
+
+    Ok(())
+}

--- a/whisper/src/lib.rs
+++ b/whisper/src/lib.rs
@@ -65,7 +65,7 @@ const METADATA_SIZE: usize = 16;
 const ARCHIVE_INFO_SIZE: usize = 12;
 pub const POINT_SIZE: usize = 12;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct WhisperMetadata {
     pub aggregation_method: AggregationMethod,
     pub max_retention: u32,
@@ -261,7 +261,8 @@ fn __set_aggregation(path: &Path, aggregation_method: Option<AggregationMethod>,
     // if LOCK:
     //     fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
 
-    let mut info = __read_header(&mut fh)?;
+    let old_info = __read_header(&mut fh)?;
+    let mut info = old_info.clone();
 
     if let Some(aggregation_method) = aggregation_method {
         info.aggregation_method = aggregation_method;
@@ -279,7 +280,7 @@ fn __set_aggregation(path: &Path, aggregation_method: Option<AggregationMethod>,
     // if CACHE_HEADERS and fh.name in __headerCache:
     //     del __headerCache[fh.name]
 
-    Ok(info)
+    Ok(old_info)
 }
 
 /**

--- a/whisper/tests/test-whisper-set-xfilesfactor.rs
+++ b/whisper/tests/test-whisper-set-xfilesfactor.rs
@@ -1,0 +1,24 @@
+extern crate assert_cli;
+
+#[cfg(test)]
+mod whisper_set_xfilesfactor {
+    use assert_cli;
+
+    const NAME: &str = "whisper-set-xfilesfactor";
+
+    #[test]
+    fn calling_without_args() {
+        assert_cli::Assert::cargo_binary(NAME)
+            .fails_with(1)
+            .stderr().contains("USAGE")
+            .unwrap();
+    }
+
+    #[test]
+    fn calling_help() {
+        assert_cli::Assert::cargo_binary(NAME)
+            .with_args(&["--help"])
+            .stdout().contains("USAGE")
+            .unwrap();
+    }
+}


### PR DESCRIPTION
* add whisper-set-xfilesfactor
* reformat whisper-set-aggregation-method close to python version
* fix the python cli behaviour: returns the old aggregationMethod and old xFilesFactor:

```
../target/debug/whisper-set-aggregation-method 1.wsp average
Updated aggregation method: 1.wsp (average -> average)

../target/debug/whisper-set-aggregation-method 1.wsp last
Updated aggregation method: 1.wsp (last -> last)
```