### PR TITLE
Refactoring find corrupt

### DIFF
--- a/whisper/src/bin/find-corrupt-whisper-files.rs
+++ b/whisper/src/bin/find-corrupt-whisper-files.rs
@@ -69,9 +69,7 @@ fn delete_corrupt_file(file: &Path, delete_corrupt: bool) -> Result<(), Error> {
     Ok(())
 }
 
-fn main() -> Result<(), Error> {
-    let args = Args::from_args();
-
+fn run(args: &Args) -> Result<(), Error> {
     for dir in &args.directories {
         if !dir.is_dir() {
             eprintln!("{} is not a directory or not exist!", dir.display());
@@ -86,4 +84,12 @@ fn main() -> Result<(), Error> {
     }
 
     Ok(())
+}
+
+fn main() {
+    let args = Args::from_args();
+    if let Err(err) = run(&args) {
+        eprintln!("{}", err);
+        exit(1);
+    }
 }

--- a/whisper/src/bin/find-corrupt-whisper-files.rs
+++ b/whisper/src/bin/find-corrupt-whisper-files.rs
@@ -42,9 +42,9 @@ fn is_whisper_file(path: &Path) -> bool {
 fn walk_dir(dir: &Path, delete_corrupt: bool, verbose: bool) -> Result<(), Error> {
     for entry in WalkDir::new(dir).min_depth(1).into_iter() {
         match entry {
-            Ok(ref entry) if entry.path().is_dir() && verbose => println!(
-                "Scanning {}...", entry.path().canonicalize()?.display()
-            ),
+            Ok(ref entry) if entry.path().is_dir() && verbose => {
+                println!("Scanning {}...", entry.path().canonicalize()?.display())
+            }
             Ok(ref entry) if is_whisper_file(entry.path()) => {
                 delete_corrupt_file(&entry.path(), delete_corrupt)?
             }

--- a/whisper/src/bin/find-corrupt-whisper-files.rs
+++ b/whisper/src/bin/find-corrupt-whisper-files.rs
@@ -11,27 +11,20 @@ use std::process::exit;
 use structopt::StructOpt;
 use walkdir::WalkDir;
 
+/// Find and (optionally) delete corrupt Whisper data files.
 #[derive(Debug, StructOpt)]
-#[structopt(
-    name = "find-corrupt-whisper-files",
-    about = "Find and (optionally) delete corrupt Whisper data files."
-)]
+#[structopt(name = "find-corrupt-whisper-files")]
 struct Args {
     /// Delete reported files.
-    #[structopt(long = "delete-corrupt", help = "Delete reported files")]
+    #[structopt(long = "delete-corrupt")]
     delete_corrupt: bool,
 
     /// Display progress info.
-    #[structopt(long = "verbose", help = "Display progress info")]
+    #[structopt(long = "verbose")]
     verbose: bool,
 
     /// Directory containing Whisper files.
-    #[structopt(
-        name = "WHISPER_DIR",
-        help = "Directory containing Whisper files",
-        parse(from_os_str),
-        raw(required = "true", min_values = "1")
-    )]
+    #[structopt(name = "WHISPER_DIR", parse(from_os_str), raw(required = "true", min_values = "1"))]
     directories: Vec<PathBuf>,
 }
 

--- a/whisper/src/bin/find-corrupt-whisper-files.rs
+++ b/whisper/src/bin/find-corrupt-whisper-files.rs
@@ -42,21 +42,23 @@ fn is_whisper_file(path: &Path) -> bool {
 fn walk_dir(dir: &Path, delete_corrupt: bool, verbose: bool) -> Result<(), Error> {
     for entry in WalkDir::new(dir).min_depth(1).into_iter() {
         match entry {
-            Ok(ref entry) if entry.path().is_dir() && verbose => {
+            Ok(ref entry) if verbose && entry.file_type().is_dir() => {
                 println!("Scanning {}...", entry.path().canonicalize()?.display())
             }
             Ok(ref entry) if is_whisper_file(entry.path()) => {
                 delete_corrupt_file(&entry.path(), delete_corrupt)?
             }
-            Err(e) => eprintln!("{}", e),
-            _ => (),
+            Err(e) => {
+                eprintln!("{}", e)
+            }
+            _ => {}
         }
     }
 
     Ok(())
 }
 
-fn delete_corrupt_file(file: &Path, delete_corrupt: bool)  -> Result<(), Error> {
+fn delete_corrupt_file(file: &Path, delete_corrupt: bool) -> Result<(), Error> {
     match whisper::WhisperFile::open(file) {
         Ok(whisper_file) => {
             let x: u32 = whisper_file.info().archives.iter().map(|a| a.points).sum();


### PR DESCRIPTION
Fix format output like in original script:
* added directory list output during traversal
* add absolute path list  instead of relative

Other:
* Convert filtermap+map to cycle
* Added error support
* cleanup duplicates in help and docstrings