### PR TITLE
fix all relevant clippy messages

### DIFF
--- a/whisper/src/aggregation.rs
+++ b/whisper/src/aggregation.rs
@@ -38,7 +38,7 @@ impl AggregationMethod {
         }
     }
 
-    pub fn to_type(&self) -> u32 {
+    pub fn to_type(self) -> u32 {
         match self {
             AggregationMethod::Average => 1,
             AggregationMethod::Sum => 2,
@@ -51,7 +51,7 @@ impl AggregationMethod {
         }
     }
 
-    pub fn aggregate(&self, values: &[Option<f64>]) -> Result<f64, &'static str> {
+    pub fn aggregate(self, values: &[Option<f64>]) -> Result<f64, &'static str> {
         match self {
             AggregationMethod::Average => {
                 let sum: f64 = values.iter().filter_map(|v| *v).sum();

--- a/whisper/src/bin/find-corrupt-whisper-files.rs
+++ b/whisper/src/bin/find-corrupt-whisper-files.rs
@@ -33,7 +33,7 @@ fn is_whisper_file(path: &Path) -> bool {
 }
 
 fn walk_dir(dir: &Path, delete_corrupt: bool, verbose: bool) -> Result<(), Error> {
-    for entry in WalkDir::new(dir).min_depth(1).into_iter() {
+    for entry in WalkDir::new(dir).min_depth(1) {
         match entry {
             Ok(ref entry) if verbose && entry.file_type().is_dir() => {
                 println!("Scanning {}...", entry.path().canonicalize()?.display())

--- a/whisper/src/bin/whisper-dump.rs
+++ b/whisper/src/bin/whisper-dump.rs
@@ -53,7 +53,7 @@ fn run(args: &Args) -> Result<(), Error> {
         for (j, point) in points.iter().enumerate() {
             match (&args.pretty, &args.time_format) {
                 (true, Some(time_format)) => {
-                    let timestr = NaiveDateTime::from_timestamp(point.interval as i64, 0)
+                    let timestr = NaiveDateTime::from_timestamp(i64::from(point.interval), 0)
                         .format(&time_format);
                     println!("{}: {}, {:>10}", j, timestr, &point.value);
                 }

--- a/whisper/src/bin/whisper-fetch.rs
+++ b/whisper/src/bin/whisper-fetch.rs
@@ -73,7 +73,7 @@ fn run(args: &Args) -> Result<(), Error> {
     let mut file = WhisperFile::open(&args.path)?;
 
     let seconds_per_point = whisper::suggest_archive(&file, interval, now)
-        .ok_or(err_msg("No data in selected timerange"))?;
+        .ok_or_else(|| err_msg("No data in selected timerange"))?;
 
     let filter = match args.drop {
         Some(ref s) if s == "nulls" => is_not_null,
@@ -84,7 +84,7 @@ fn run(args: &Args) -> Result<(), Error> {
     };
 
     let archive = file.fetch(seconds_per_point, interval, now)?
-        .ok_or(err_msg("No data in selected timerange"))?
+        .ok_or_else(|| err_msg("No data in selected timerange"))?
         .filter_out(&filter);
 
     if args.json {

--- a/whisper/src/builder.rs
+++ b/whisper/src/builder.rs
@@ -87,7 +87,7 @@ impl WhisperBuilder {
     pub fn build(self, path: impl AsRef<Path>) -> Result<WhisperFile, BuilderError> {
         let sparse = self.sparse;
         let metadata = self.into_metadata()?;
-        let file = WhisperFile::create(metadata, path.as_ref(), sparse).map_err(BuilderError::Io)?;
+        let file = WhisperFile::create(&metadata, path.as_ref(), sparse).map_err(BuilderError::Io)?;
         Ok(file)
     }
 }

--- a/whisper/src/interval.rs
+++ b/whisper/src/interval.rs
@@ -17,23 +17,23 @@ impl Interval {
         Self { from: until - duration, until }
     }
 
-    pub fn from(&self) -> u32 {
+    pub fn from(self) -> u32 {
         self.from
     }
 
-    pub fn until(&self) -> u32 {
+    pub fn until(self) -> u32 {
         self.until
     }
 
-    pub fn contains(&self, other: Interval) -> bool {
+    pub fn contains(self, other: Interval) -> bool {
         self.from <= other.from && other.until <= self.until
     }
 
-    pub fn intersects(&self, other: Interval) -> bool {
+    pub fn intersects(self, other: Interval) -> bool {
         self.from <= other.until && self.until >= other.from
     }
 
-    pub fn intersection(&self, other: Interval) -> Result<Interval, String> {
+    pub fn intersection(self, other: Interval) -> Result<Interval, String> {
         Interval::new(
             u32::max(self.from, other.from),
             u32::min(self.until, other.until)

--- a/whisper/src/lib.rs
+++ b/whisper/src/lib.rs
@@ -138,7 +138,7 @@ pub struct WhisperFile {
 }
 
 impl WhisperFile {
-    fn create(header: WhisperMetadata, path: &Path, sparse: bool) -> Result<Self, io::Error> {
+    fn create(header: &WhisperMetadata, path: &Path, sparse: bool) -> Result<Self, io::Error> {
         let mut metainfo_bytes = Vec::<u8>::new();
         header.write(&mut metainfo_bytes)?;
 
@@ -246,7 +246,7 @@ impl WhisperFile {
         let interval = available.intersection(interval)
             .map_err(|s| io::Error::new(io::ErrorKind::Other, s))?;
 
-        let adjusted_interval = adjust_interval(&interval, archive.seconds_per_point)
+        let adjusted_interval = adjust_interval(interval, archive.seconds_per_point)
             .map_err(|s| io::Error::new(io::ErrorKind::Other, s))?;
 
         let points = archive_fetch_interval(&mut self.file, &archive, adjusted_interval)?;
@@ -594,7 +594,7 @@ fn adjust_instant_up(instant: u32, step: u32) -> u32 {
     (instant + step - 1) / step * step
 }
 
-fn adjust_interval(interval: &Interval, step: u32) -> Result<Interval, String> {
+fn adjust_interval(interval: Interval, step: u32) -> Result<Interval, String> {
     let from_interval = adjust_instant(interval.from(), step);
     let until_interval = adjust_instant_up(interval.until(), step);
 

--- a/whisper/src/point.rs
+++ b/whisper/src/point.rs
@@ -34,7 +34,7 @@ impl FromStr for Point {
     type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Point, Self::Err> {
-        let segments: Vec<&str> = s.split(":").collect();
+        let segments: Vec<&str> = s.split(':').collect();
 
         let (interval, value) = match segments.len() {
             2 => (segments[0], segments[1]),

--- a/whisper/src/retention.rs
+++ b/whisper/src/retention.rs
@@ -26,7 +26,7 @@ pub struct Retention {
 }
 
 impl Retention {
-    pub fn retention(&self) -> u32 {
+    pub fn retention(self) -> u32 {
         self.seconds_per_point * self.points
     }
 }


### PR DESCRIPTION
```
    Checking whisper v0.1.0 (file:///Users/ander/work/garden-team/graphite-rs/whisper)
warning: this argument is passed by reference, but would be more efficient if passed by value
  --> whisper/src/interval.rs:20:17
   |
20 |     pub fn from(&self) -> u32 {
   |                 ^^^^^ help: consider passing by value instead: `self`
   |
   = note: #[warn(trivially_copy_pass_by_ref)] on by default
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#trivially_copy_pass_by_ref

warning: this argument is passed by reference, but would be more efficient if passed by value
  --> whisper/src/interval.rs:24:18
   |
24 |     pub fn until(&self) -> u32 {
   |                  ^^^^^ help: consider passing by value instead: `self`
   |
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#trivially_copy_pass_by_ref

warning: this argument is passed by reference, but would be more efficient if passed by value
  --> whisper/src/interval.rs:28:21
   |
28 |     pub fn contains(&self, other: Interval) -> bool {
   |                     ^^^^^ help: consider passing by value instead: `self`
   |
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#trivially_copy_pass_by_ref

warning: this argument is passed by reference, but would be more efficient if passed by value
  --> whisper/src/interval.rs:32:23
   |
32 |     pub fn intersects(&self, other: Interval) -> bool {
   |                       ^^^^^ help: consider passing by value instead: `self`
   |
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#trivially_copy_pass_by_ref

warning: this argument is passed by reference, but would be more efficient if passed by value
  --> whisper/src/interval.rs:36:25
   |
36 |     pub fn intersection(&self, other: Interval) -> Result<Interval, String> {
   |                         ^^^^^ help: consider passing by value instead: `self`
   |
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#trivially_copy_pass_by_ref

warning: this argument is passed by reference, but would be more efficient if passed by value
 --> whisper/src/aggregation.rs:6:15
  |
6 | fn cmp_f64(a: &f64, b: &f64) -> cmp::Ordering {
  |               ^^^^ help: consider passing by value instead: `f64`
  |
  = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#trivially_copy_pass_by_ref

warning: this argument is passed by reference, but would be more efficient if passed by value
 --> whisper/src/aggregation.rs:6:24
  |
6 | fn cmp_f64(a: &f64, b: &f64) -> cmp::Ordering {
  |                        ^^^^ help: consider passing by value instead: `f64`
  |
  = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#trivially_copy_pass_by_ref

warning: this argument is passed by reference, but would be more efficient if passed by value
  --> whisper/src/aggregation.rs:10:19
   |
10 | fn cmp_f64_abs(a: &f64, b: &f64) -> cmp::Ordering {
   |                   ^^^^ help: consider passing by value instead: `f64`
   |
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#trivially_copy_pass_by_ref

warning: this argument is passed by reference, but would be more efficient if passed by value
  --> whisper/src/aggregation.rs:10:28
   |
10 | fn cmp_f64_abs(a: &f64, b: &f64) -> cmp::Ordering {
   |                            ^^^^ help: consider passing by value instead: `f64`
   |
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#trivially_copy_pass_by_ref

warning: this argument is passed by reference, but would be more efficient if passed by value
  --> whisper/src/aggregation.rs:41:20
   |
41 |     pub fn to_type(&self) -> u32 {
   |                    ^^^^^ help: consider passing by value instead: `self`
   |
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#trivially_copy_pass_by_ref

warning: this argument is passed by reference, but would be more efficient if passed by value
  --> whisper/src/aggregation.rs:54:22
   |
54 |     pub fn aggregate(&self, values: &[Option<f64>]) -> Result<f64, &'static str> {
   |                      ^^^^^ help: consider passing by value instead: `self`
   |
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#trivially_copy_pass_by_ref

warning: this argument is passed by reference, but would be more efficient if passed by value
  --> whisper/src/retention.rs:29:22
   |
29 |     pub fn retention(&self) -> u32 {
   |                      ^^^^^ help: consider passing by value instead: `self`
   |
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#trivially_copy_pass_by_ref

warning: single-character string constant used as pattern
  --> whisper/src/point.rs:37:43
   |
37 |         let segments: Vec<&str> = s.split(":").collect();
   |                                   --------^^^- help: try using a char instead: `s.split(':')`
   |
   = note: #[warn(single_char_pattern)] on by default
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#single_char_pattern

warning: this argument is passed by value, but not consumed in the function body
   --> whisper/src/lib.rs:143:23
    |
143 |     fn create(header: WhisperMetadata, path: &Path, sparse: bool) -> Result<Self, io::Error> {
    |                       ^^^^^^^^^^^^^^^ help: consider taking a reference instead: `&WhisperMetadata`
    |
    = note: #[warn(needless_pass_by_value)] on by default
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#needless_pass_by_value

warning: this argument is passed by reference, but would be more efficient if passed by value
   --> whisper/src/lib.rs:597:30
    |
597 | fn adjust_interval(interval: &Interval, step: u32) -> Result<Interval, String> {
    |                              ^^^^^^^^^ help: consider passing by value instead: `Interval`
    |
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#trivially_copy_pass_by_ref

warning: it is more idiomatic to loop over containers instead of using explicit iteration methods`
  --> whisper/src/bin/find-corrupt-whisper-files.rs:36:18
   |
36 |     for entry in WalkDir::new(dir).min_depth(1).into_iter() {
   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: to write this more concisely, try: `WalkDir::new(dir).min_depth(1)`
   |
   = note: #[warn(explicit_into_iter_loop)] on by default
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#explicit_into_iter_loop

    Checking whisper_tests v0.1.0 (file:///Users/ander/work/garden-team/graphite-rs/whisper_tests)
warning: use of `ok_or` followed by a function call
  --> whisper/src/bin/whisper-fetch.rs:76:10
   |
76 |         .ok_or(err_msg("No data in selected timerange"))?;
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `ok_or_else(|| err_msg("No data in selected timerange"))`
   |
   = note: #[warn(or_fun_call)] on by default
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#or_fun_call

warning: use of `ok_or` followed by a function call
  --> whisper/src/bin/whisper-fetch.rs:87:10
   |
87 |         .ok_or(err_msg("No data in selected timerange"))?
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `ok_or_else(|| err_msg("No data in selected timerange"))`
   |
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#or_fun_call

warning: casting u32 to i64 may become silently lossy if types change
  --> whisper/src/bin/whisper-dump.rs:56:65
   |
56 |                     let timestr = NaiveDateTime::from_timestamp(point.interval as i64, 0)
   |                                                                 ^^^^^^^^^^^^^^^^^^^^^ help: try: `i64::from(point.interval)`
   |
   = note: #[warn(cast_lossless)] on by default
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#cast_lossless
```