### PR TITLE
Backport some changes from #181 into separate PR

### DIFF
--- a/whisper/src/bin/whisper-fetch.rs
+++ b/whisper/src/bin/whisper-fetch.rs
@@ -77,7 +77,6 @@ fn run(args: &Args) -> Result<(), Error> {
 
     let archive = file
         .fetch(seconds_per_point, interval, now)?
-        .ok_or_else(|| err_msg("No data in selected timerange"))?
         .filter_out(&filter);
 
     if args.json {

--- a/whisper/src/bin/whisper-fetch.rs
+++ b/whisper/src/bin/whisper-fetch.rs
@@ -64,7 +64,8 @@ fn run(args: &Args) -> Result<(), Error> {
     let interval = Interval::new(from, until).map_err(err_msg)?;
     let mut file = WhisperFile::open(&args.path)?;
 
-    let seconds_per_point = whisper::suggest_archive(&file, interval, now)
+    let seconds_per_point = file
+        .suggest_archive(interval, now)
         .ok_or_else(|| err_msg("No data in selected timerange"))?;
 
     let filter = match args.drop {

--- a/whisper/src/diff.rs
+++ b/whisper/src/diff.rs
@@ -175,8 +175,8 @@ pub fn diff(path1: &Path, path2: &Path, ignore_empty: bool, mut until_time: u32,
         let start_time = now - archive.retention();
         let interval = Interval::new(start_time, until_time).unwrap();
 
-        let data1 = file1.fetch(archive.seconds_per_point, interval, now)?.unwrap();
-        let data2 = file2.fetch(archive.seconds_per_point, interval, now)?.unwrap();
+        let data1 = file1.fetch(archive.seconds_per_point, interval, now)?;
+        let data2 = file2.fetch(archive.seconds_per_point, interval, now)?;
 
         let start = u32::min(data1.from_interval, data2.from_interval);
         let end = u32::max(data1.until_interval, data2.until_interval);

--- a/whisper/src/fill.rs
+++ b/whisper/src/fill.rs
@@ -84,8 +84,7 @@ pub fn fill(src: &Path, dst: &Path, from: u32, now: u32) -> Result<(), io::Error
 
         let interval = Interval::new(from_time, start_from).unwrap();
         let data_dst = file_dst
-            .fetch(archive.seconds_per_point, interval, now)?
-            .unwrap();
+            .fetch(archive.seconds_per_point, interval, now)?;
 
         let mut start = data_dst.from_interval;
         let end = data_dst.until_interval;

--- a/whisper/src/lib.rs
+++ b/whisper/src/lib.rs
@@ -1,9 +1,8 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-use failure;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
-use std::io::{self, Read, Write, Seek};
 use std::fs;
+use std::io::{self, Read, Seek, Write};
 use std::path::Path;
 
 /*
@@ -227,6 +226,19 @@ impl WhisperFile {
             .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Archive not found"))
     }
 
+    pub fn suggest_archive(&self, interval: Interval, now: u32) -> Option<u32> {
+        let meta = self.info();
+
+        let adjusted = Interval::past(now, meta.max_retention)
+            .intersection(interval)
+            .ok()?;
+
+        meta.archives
+            .iter()
+            .filter(|archive| Interval::past(now, archive.retention()).contains(adjusted))
+            .map(|archive| archive.seconds_per_point)
+            .next()
+    }
     pub fn fetch_points(&mut self, seconds_per_point: u32, interval: Interval, now: u32) -> Result<(Interval, Option<Vec<Point>>), io::Error> {
         let archive = self.find_archive(seconds_per_point)?;
         let available = Interval::past(now, self.metadata.max_retention);
@@ -247,10 +259,20 @@ impl WhisperFile {
         Ok((adjusted_interval, points))
     }
 
-    pub fn fetch(&mut self, seconds_per_point: u32, interval: Interval, now: u32) -> Result<Option<ArchiveData>, io::Error> {
+    pub fn fetch_auto_points(&mut self, interval: Interval, now: u32) -> Result<ArchiveData, io::Error> {
+        let seconds_per_point = self
+            .suggest_archive(interval, now)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "No data in selected timerange"))?;
+
         let (adjusted_interval, points) = self.fetch_points(seconds_per_point, interval, now)?;
         let data = points_to_data(&points, adjusted_interval, seconds_per_point);
-        Ok(Some(data))
+        Ok(data)
+    }
+
+    pub fn fetch(&mut self, seconds_per_point: u32, interval: Interval, now: u32) -> Result<ArchiveData, io::Error> {
+        let (adjusted_interval, points) = self.fetch_points(seconds_per_point, interval, now)?;
+        let data = points_to_data(&points, adjusted_interval, seconds_per_point);
+        Ok(data)
     }
 
     pub fn dump(&mut self, seconds_per_point: u32) -> Result<Vec<Point>, io::Error> {
@@ -260,15 +282,7 @@ impl WhisperFile {
 }
 
 pub fn suggest_archive(file: &WhisperFile, interval: Interval, now: u32) -> Option<u32> {
-    let meta = file.info();
-
-    let adjusted = Interval::past(now, meta.max_retention)
-        .intersection(interval).ok()?;
-
-    meta.archives.iter()
-        .filter(|archive| Interval::past(now, archive.retention()).contains(adjusted))
-        .map(|archive| archive.seconds_per_point)
-        .next()
+    file.suggest_archive(interval, now)
 }
 
 fn instant_offset(archive: &ArchiveInfo, base_interval: u32, instant: u32) -> u32 {

--- a/whisper/src/lib.rs
+++ b/whisper/src/lib.rs
@@ -239,6 +239,7 @@ impl WhisperFile {
             .map(|archive| archive.seconds_per_point)
             .next()
     }
+
     pub fn fetch_points(&mut self, seconds_per_point: u32, interval: Interval, now: u32) -> Result<(Interval, Option<Vec<Point>>), io::Error> {
         let archive = self.find_archive(seconds_per_point)?;
         let available = Interval::past(now, self.metadata.max_retention);
@@ -279,10 +280,6 @@ impl WhisperFile {
         let archive = self.find_archive(seconds_per_point)?;
         read_archive(&mut self.file, &archive, 0, archive.points)
     }
-}
-
-pub fn suggest_archive(file: &WhisperFile, interval: Interval, now: u32) -> Option<u32> {
-    file.suggest_archive(interval, now)
 }
 
 fn instant_offset(archive: &ArchiveInfo, base_interval: u32, instant: u32) -> u32 {

--- a/whisper_tests/benches/tests.rs
+++ b/whisper_tests/benches/tests.rs
@@ -2,7 +2,7 @@ use bencher::Bencher;
 use bencher::{benchmark_main, benchmark_group};
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
-use whisper::{WhisperFile, suggest_archive};
+use whisper::WhisperFile;
 use whisper::builder::{WhisperBuilder, BuilderError};
 use whisper::retention::Retention;
 use whisper::point::Point;
@@ -72,7 +72,7 @@ fn test_fetch(bench: &mut Bencher) {
     let until_time = from_time + 1000;
     let interval = Interval::new(from_time, until_time).expect("interval");
     bench.iter(|| {
-        let seconds_per_point = suggest_archive(&file, interval, now).expect("Archive");
+        let seconds_per_point = file.suggest_archive(interval, now).expect("Archive");
         file.fetch(seconds_per_point, interval, now).expect("fetch");
     });
 }
@@ -94,7 +94,7 @@ fn test_update_fetch(bench: &mut Bencher) {
             file.update(&Point { interval: now - SECONDS_AGO + j, value: *i}, now).expect("update");
             *i += VALUE_STEP;
         }
-        let seconds_per_point = suggest_archive(&file, interval, now).expect("Archive");
+        let seconds_per_point = file.suggest_archive(interval, now).expect("Archive");
         file.fetch(seconds_per_point, interval, now).expect("fetch");
     });
 }

--- a/whisper_tests/tests/test-whisper.rs
+++ b/whisper_tests/tests/test-whisper.rs
@@ -4,7 +4,6 @@ use whisper::builder::WhisperBuilder;
 use whisper::interval::Interval;
 use whisper::point::Point;
 use whisper::retention::Retention;
-use whisper::suggest_archive;
 use whisper_tests::{get_temp_dir, get_file_path};
 
 #[test]
@@ -49,8 +48,7 @@ fn whisper_suggest_archive() -> Result<(), Error> {
     file.update_many(&points, now)?;
 
     assert_eq!(
-        suggest_archive(
-            &file,
+        file.suggest_archive(
             Interval::new(now - 600, now - 60).map_err(err_msg)?,
             now
         ),
@@ -58,8 +56,7 @@ fn whisper_suggest_archive() -> Result<(), Error> {
     );
 
     assert_eq!(
-        suggest_archive(
-            &file,
+        file.suggest_archive(
             Interval::new(now - 1200, now - 600).map_err(err_msg)?,
             now
         ),
@@ -67,8 +64,7 @@ fn whisper_suggest_archive() -> Result<(), Error> {
     );
 
     assert_eq!(
-        suggest_archive(
-            &file,
+        file.suggest_archive(
             Interval::new(now - 6000, now - 3000).map_err(err_msg)?,
             now
         ),
@@ -76,8 +72,7 @@ fn whisper_suggest_archive() -> Result<(), Error> {
     );
 
     assert_eq!(
-        suggest_archive(
-            &file,
+        file.suggest_archive(
             Interval::new(now - 12000, now - 6060).map_err(err_msg)?,
             now
         ),

--- a/whisper_tests/tests/test-whisper.rs
+++ b/whisper_tests/tests/test-whisper.rs
@@ -1,0 +1,88 @@
+use failure::*;
+
+use whisper::builder::WhisperBuilder;
+use whisper::interval::Interval;
+use whisper::point::Point;
+use whisper::retention::Retention;
+use whisper::suggest_archive;
+use whisper_tests::{get_temp_dir, get_file_path};
+
+#[test]
+fn whisper_suggest_archive() -> Result<(), Error> {
+    let temp_dir = get_temp_dir();
+    let path = get_file_path(&temp_dir, "suggest");
+
+    let now = 1528240800;
+
+    let mut file = WhisperBuilder::default()
+        .add_retention(Retention {
+            seconds_per_point: 60,
+            points: 10,
+        })
+        .add_retention(Retention {
+            seconds_per_point: 300,
+            points: 10,
+        })
+        .add_retention(Retention {
+            seconds_per_point: 600,
+            points: 10,
+        })
+        .build(path)?;
+
+    let points: Vec<Point> = [
+        now - 60,
+        now - 300,
+        now - 360,
+        now - 600,
+        now - 900,
+        now - 1200,
+        now - 3600,
+        now - 6000,
+    ]
+    .iter()
+    .map(|interval| Point {
+        interval: *interval,
+        value: rand::random(),
+    })
+    .collect();
+
+    file.update_many(&points, now)?;
+
+    assert_eq!(
+        suggest_archive(
+            &file,
+            Interval::new(now - 600, now - 60).map_err(err_msg)?,
+            now
+        ),
+        Some(60)
+    );
+
+    assert_eq!(
+        suggest_archive(
+            &file,
+            Interval::new(now - 1200, now - 600).map_err(err_msg)?,
+            now
+        ),
+        Some(300)
+    );
+
+    assert_eq!(
+        suggest_archive(
+            &file,
+            Interval::new(now - 6000, now - 3000).map_err(err_msg)?,
+            now
+        ),
+        Some(600)
+    );
+
+    assert_eq!(
+        suggest_archive(
+            &file,
+            Interval::new(now - 12000, now - 6060).map_err(err_msg)?,
+            now
+        ),
+        None
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Backport some changes from #181 into separate PR:
* remove unnecessary option from `fetch`
* initial implementation of `fetch_auto_points` (`fetch` with auto-detection of seconds_per_point)
* create a WhisperFile impl method `suggest_archive` and leave function for the compatibility.
* ~~add test cases for `adjust_interval`~~
* ~~refactor `adjust_interval`, which always should provide safe result without error.~~
* add test cases for `suggest_archive`