### PR TITLE
move and share parse_time function

### DIFF
--- a/graphite-api/src/error.rs
+++ b/graphite-api/src/error.rs
@@ -1,3 +1,4 @@
+use glob::PatternError;
 use std::convert::From;
 use std::error::Error;
 use std::fmt;
@@ -11,6 +12,8 @@ pub enum ParseError {
     ParseIntError(ParseIntError),
     EmptyString,
     Time,
+    Unknown,
+    Pattern(usize, &'static str),
 }
 
 impl fmt::Display for ParseError {
@@ -25,6 +28,10 @@ impl fmt::Display for ParseError {
             ),
             ParseError::ParseIntError(s) => write!(f, "{}", s),
             ParseError::EmptyString => write!(f, "Cannot parse empty string"),
+            ParseError::Unknown => write!(f, "Unknown parse error"),
+            ParseError::Pattern(pos, msg) => {
+                write!(f, "Pattern syntax error near position {}: {}", pos, msg)
+            }
         }
     }
 }
@@ -40,5 +47,11 @@ impl From<SystemTimeError> for ParseError {
 impl From<ParseIntError> for ParseError {
     fn from(error: ParseIntError) -> Self {
         ParseError::ParseIntError(error)
+    }
+}
+
+impl From<PatternError> for ParseError {
+    fn from(error: PatternError) -> Self {
+        ParseError::Pattern(error.pos, error.msg)
     }
 }

--- a/graphite-api/src/lib.rs
+++ b/graphite-api/src/lib.rs
@@ -3,3 +3,4 @@ pub mod error;
 pub mod find;
 pub mod opts;
 pub mod render;
+pub mod parse;

--- a/graphite-api/src/parse/mod.rs
+++ b/graphite-api/src/parse/mod.rs
@@ -1,0 +1,3 @@
+mod time;
+
+pub use time::*;

--- a/graphite-api/src/parse/time.rs
+++ b/graphite-api/src/parse/time.rs
@@ -1,0 +1,65 @@
+use crate::error::ParseError;
+use serde::{Deserialize, Deserializer};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub fn de_time_parse<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    time_parse(String::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+}
+
+pub fn time_parse(s: String) -> Result<u32, ParseError> {
+    if s.starts_with('-') {
+        // Relative time
+        let (multi, count) = match &s.chars().last().unwrap() {
+            's' => (1, 1),
+            'h' => (3600, 1),
+            'd' => (3600 * 24, 1),
+            'w' => (3600 * 24 * 7, 1),
+            'y' => (3600 * 24 * 365, 1),
+            'n' if s.ends_with("min") => (60, 3),
+            'n' if s.ends_with("mon") => (3600 * 24 * 30, 3),
+            _ => return Err(ParseError::Time),
+        };
+
+        let s2 = &s[1..s.len() - count];
+        let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() as u32;
+
+        let v = now - s2.parse::<u32>()? * multi;
+        Ok(v)
+    } else {
+        // Absolute time
+        match s.as_str() {
+            "now" => Ok(SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() as u32),
+            "yesterday" => {
+                Ok(SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() as u32 - 3600 * 24)
+            }
+            "" => Err(ParseError::EmptyString),
+            // Unix timestamp parse as default
+            _ => {
+                // Unix timestamp
+                Ok(s.parse::<u32>()?)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_de_time_parse_ok() {
+        let mut de = serde_json::Deserializer::new(serde_json::de::StrRead::new("\"123\""));
+        let ts = de_time_parse(&mut de).unwrap();
+        assert_eq!(ts, 123_u32);
+    }
+
+    #[test]
+    fn test_de_time_parse_error() {
+        let mut de = serde_json::Deserializer::new(serde_json::de::StrRead::new("\"lol\""));
+        let err = de_time_parse(&mut de).unwrap_err();
+        assert_eq!(err.to_string().as_str(), "invalid digit found in string");
+    }
+}

--- a/graphite-api/src/render.rs
+++ b/graphite-api/src/render.rs
@@ -1,21 +1,19 @@
-use actix_web::{HttpResponse, Json, State};
+use actix_web::{FromRequest, HttpMessage, HttpRequest, HttpResponse, Json, State};
 use failure::*;
+use futures::future::Future;
+use serde::Deserialize;
 use serde::*;
-use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
 use std::iter::successors;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use whisper::interval::Interval;
-use whisper::{WhisperFile, ArchiveData};
-
-use actix_web::{FromRequest, HttpRequest};
-use serde::{Deserialize, Deserializer};
-use std::str::FromStr;
+use whisper::{ArchiveData, WhisperFile};
 
 use crate::error::ParseError;
 use crate::opts::*;
-use actix_web::HttpMessage;
-use futures::future::Future;
+use crate::parse::{de_time_parse, time_parse};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct RenderQuery {
@@ -57,49 +55,6 @@ impl<S: 'static> FromRequest<S> for RenderQuery {
             "application/x-www-form-urlencoded" => Ok(String::extract(req)?.wait()?.parse()?),
             "application/json" => Ok(Json::<RenderQuery>::extract(req).wait()?.into_inner()),
             _ => Ok(req.query_string().parse()?),
-        }
-    }
-}
-
-pub fn de_time_parse<'de, D>(deserializer: D) -> Result<u32, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    time_parse(String::deserialize(deserializer)?).map_err(serde::de::Error::custom)
-}
-
-pub fn time_parse(s: String) -> Result<u32, ParseError> {
-    if s.starts_with('-') {
-        // Relative time
-        let (multi, count) = match &s.chars().last().unwrap() {
-            's' => (1, 1),
-            'h' => (3600, 1),
-            'd' => (3600 * 24, 1),
-            'w' => (3600 * 24 * 7, 1),
-            'y' => (3600 * 24 * 365, 1),
-            'n' if s.ends_with("min") => (60, 3),
-            'n' if s.ends_with("mon") => (3600 * 24 * 30, 3),
-            _ => return Err(ParseError::Time),
-        };
-
-        let s2 = &s[1..s.len() - count];
-        let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() as u32;
-
-        let v = now - s2.parse::<u32>()? * multi;
-        Ok(v)
-    } else {
-        // Absolute time
-        match s.as_str() {
-            "now" => Ok(SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() as u32),
-            "yesterday" => {
-                Ok(SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() as u32 - 3600 * 24)
-            }
-            "" => Err(ParseError::EmptyString),
-            // Unix timestamp parse as default
-            _ => {
-                // Unix timestamp
-                Ok(s.parse::<u32>()?)
-            }
         }
     }
 }
@@ -161,10 +116,17 @@ fn walk(dir: &Path, metric: &str, interval: Interval) -> Result<Vec<RenderPoint>
     let full_path = path(dir, metric)?;
     let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() as u32;
 
-    let ArchiveData { from_interval, step, values, .. } = WhisperFile::open(&full_path)?.fetch_auto_points(interval, now)?;
+    let ArchiveData {
+        from_interval,
+        step,
+        values,
+        ..
+    } = WhisperFile::open(&full_path)?.fetch_auto_points(interval, now)?;
 
     let timestamps = successors(Some(from_interval), |i| i.checked_add(step));
-    let points = values.into_iter().zip(timestamps)
+    let points = values
+        .into_iter()
+        .zip(timestamps)
         .map(|(value, time)| RenderPoint(value, time))
         .collect();
 
@@ -192,10 +154,12 @@ pub fn render_handler(state: State<Args>, params: RenderQuery) -> Result<HttpRes
     let response: Vec<RenderResponceEntry> = params
         .target
         .into_iter()
-        .map(|x| Ok(RenderResponceEntry {
-            datapoints: walk(&dir, &x, interval)?,
-            target: x,
-        }))
+        .map(|x| {
+            Ok(RenderResponceEntry {
+                datapoints: walk(&dir, &x, interval)?,
+                target: x,
+            })
+        })
         .collect::<Result<_, Error>>()?;
 
     Ok(HttpResponse::Ok().json(response))
@@ -478,19 +442,5 @@ mod tests {
 
         assert_eq!(RenderQuery::from_request(&r, &())?, params);
         Ok(())
-    }
-
-    #[test]
-    fn test_de_time_parse_ok() {
-        let mut de = serde_json::Deserializer::new(serde_json::de::StrRead::new("\"123\""));
-        let ts = de_time_parse(&mut de).unwrap();
-        assert_eq!(ts, 123_u32);
-    }
-
-    #[test]
-    fn test_de_time_parse_error() {
-        let mut de = serde_json::Deserializer::new(serde_json::de::StrRead::new("\"lol\""));
-        let err = de_time_parse(&mut de).unwrap_err();
-        assert_eq!(err.to_string().as_str(), "invalid digit found in string");
     }
 }


### PR DESCRIPTION
* move from `FindError` to shared `ParseError`
* move time parse code to separate module
* use `de_time_parse` in FindQuery